### PR TITLE
Demo new testing suite: Mockable models, Quick, and Nimble

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/steamclock/nice_components.git", branch: "main"),
         .package(url: "https://github.com/steamclock/steamclog-swift.git", branch: "master"),
-        .package(url: "https://github.com/steamclock/netable.git", branch: "master")
+        .package(url: "https://github.com/steamclock/netable.git", branch: "master"),
     ],
     targets: [
         .target(

--- a/mvvm-ios/MVVMSample.xcodeproj/project.pbxproj
+++ b/mvvm-ios/MVVMSample.xcodeproj/project.pbxproj
@@ -42,6 +42,11 @@
 		C6AA2F0028CB9AAC00731528 /* Users.json in Resources */ = {isa = PBXBuildFile; fileRef = C6AA2EFF28CB9AAC00731528 /* Users.json */; };
 		C6AA2F0228CBAD1B00731528 /* PostRepositoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6AA2F0128CBAD1B00731528 /* PostRepositoryTests.swift */; };
 		C6AA2F0528CBAE9500731528 /* MockPostService.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6AA2F0428CBAE9500731528 /* MockPostService.swift */; };
+		C6B5EF15296E17E100DC956F /* Quick in Frameworks */ = {isa = PBXBuildFile; productRef = C6B5EF14296E17E100DC956F /* Quick */; };
+		C6B5EF18296E18B400DC956F /* Nimble in Frameworks */ = {isa = PBXBuildFile; productRef = C6B5EF17296E18B400DC956F /* Nimble */; };
+		C6B5EF1B296E262800DC956F /* FactoryBird in Frameworks */ = {isa = PBXBuildFile; productRef = C6B5EF1A296E262800DC956F /* FactoryBird */; };
+		C6B5EF1D296E264400DC956F /* Post+Mockable.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6B5EF1C296E264400DC956F /* Post+Mockable.swift */; };
+		C6B5EF1F296E272B00DC956F /* User+Mockable.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6B5EF1E296E272B00DC956F /* User+Mockable.swift */; };
 		C6C97FCA28EF3EEF0089586C /* SteamclUtilityBelt in Frameworks */ = {isa = PBXBuildFile; productRef = C6C97FC928EF3EEF0089586C /* SteamclUtilityBelt */; };
 		C6C97FCC28EF43A60089586C /* InjectedValues.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6C97FCB28EF43A60089586C /* InjectedValues.swift */; };
 		C6DBE1A428CBEDEC0072C63D /* PostDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6DBE1A328CBEDEC0072C63D /* PostDetailView.swift */; };
@@ -107,6 +112,8 @@
 		C6AA2EFF28CB9AAC00731528 /* Users.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = Users.json; sourceTree = "<group>"; };
 		C6AA2F0128CBAD1B00731528 /* PostRepositoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostRepositoryTests.swift; sourceTree = "<group>"; };
 		C6AA2F0428CBAE9500731528 /* MockPostService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockPostService.swift; sourceTree = "<group>"; };
+		C6B5EF1C296E264400DC956F /* Post+Mockable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Post+Mockable.swift"; sourceTree = "<group>"; };
+		C6B5EF1E296E272B00DC956F /* User+Mockable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "User+Mockable.swift"; sourceTree = "<group>"; };
 		C6C97FC728EF3EDA0089586C /* steamclutility-belt */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = "steamclutility-belt"; path = ..; sourceTree = "<group>"; };
 		C6C97FCB28EF43A60089586C /* InjectedValues.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InjectedValues.swift; sourceTree = "<group>"; };
 		C6DBE1A328CBEDEC0072C63D /* PostDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostDetailView.swift; sourceTree = "<group>"; };
@@ -126,6 +133,9 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				C6B5EF15296E17E100DC956F /* Quick in Frameworks */,
+				C6B5EF1B296E262800DC956F /* FactoryBird in Frameworks */,
+				C6B5EF18296E18B400DC956F /* Nimble in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -335,6 +345,8 @@
 				C61DC74828D398950089E912 /* TestData.swift */,
 				C6AA2EF828CB98E900731528 /* JSON */,
 				C6AA2EF228CB980100731528 /* Mock */,
+				C6B5EF1C296E264400DC956F /* Post+Mockable.swift */,
+				C6B5EF1E296E272B00DC956F /* User+Mockable.swift */,
 			);
 			path = TestResources;
 			sourceTree = "<group>";
@@ -443,6 +455,11 @@
 				A62B2260263BABA500A0136E /* PBXTargetDependency */,
 			);
 			name = MVVMSampleTests;
+			packageProductDependencies = (
+				C6B5EF14296E17E100DC956F /* Quick */,
+				C6B5EF17296E18B400DC956F /* Nimble */,
+				C6B5EF1A296E262800DC956F /* FactoryBird */,
+			);
 			productName = MVVMSampleTests;
 			productReference = A62B225E263BABA500A0136E /* MVVMSampleTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
@@ -497,6 +514,9 @@
 			);
 			mainGroup = A62B2244263BABA400A0136E;
 			packageReferences = (
+				C6B5EF13296E17E100DC956F /* XCRemoteSwiftPackageReference "Quick" */,
+				C6B5EF16296E18B400DC956F /* XCRemoteSwiftPackageReference "Nimble" */,
+				C6B5EF19296E262800DC956F /* XCRemoteSwiftPackageReference "factory-bird" */,
 			);
 			productRefGroup = A62B224E263BABA400A0136E /* Products */;
 			projectDirPath = "";
@@ -579,9 +599,11 @@
 				C6AA2EF528CB981600731528 /* MockPostRepository.swift in Sources */,
 				C6AA2F0228CBAD1B00731528 /* PostRepositoryTests.swift in Sources */,
 				C6AA2F0528CBAE9500731528 /* MockPostService.swift in Sources */,
+				C6B5EF1F296E272B00DC956F /* User+Mockable.swift in Sources */,
 				C6AA2EEF28CB960E00731528 /* PostsViewModelTests.swift in Sources */,
 				C61DC74A28D39C090089E912 /* TestData.swift in Sources */,
 				A62B2263263BABA500A0136E /* MVVMSampleTests.swift in Sources */,
+				C6B5EF1D296E264400DC956F /* Post+Mockable.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -888,7 +910,49 @@
 		};
 /* End XCConfigurationList section */
 
+/* Begin XCRemoteSwiftPackageReference section */
+		C6B5EF13296E17E100DC956F /* XCRemoteSwiftPackageReference "Quick" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/Quick/Quick.git";
+			requirement = {
+				branch = main;
+				kind = branch;
+			};
+		};
+		C6B5EF16296E18B400DC956F /* XCRemoteSwiftPackageReference "Nimble" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/Quick/Nimble";
+			requirement = {
+				branch = main;
+				kind = branch;
+			};
+		};
+		C6B5EF19296E262800DC956F /* XCRemoteSwiftPackageReference "factory-bird" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "git@github.com:steamclock/factory-bird.git";
+			requirement = {
+				branch = main;
+				kind = branch;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
 /* Begin XCSwiftPackageProductDependency section */
+		C6B5EF14296E17E100DC956F /* Quick */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = C6B5EF13296E17E100DC956F /* XCRemoteSwiftPackageReference "Quick" */;
+			productName = Quick;
+		};
+		C6B5EF17296E18B400DC956F /* Nimble */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = C6B5EF16296E18B400DC956F /* XCRemoteSwiftPackageReference "Nimble" */;
+			productName = Nimble;
+		};
+		C6B5EF1A296E262800DC956F /* FactoryBird */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = C6B5EF19296E262800DC956F /* XCRemoteSwiftPackageReference "factory-bird" */;
+			productName = FactoryBird;
+		};
 		C6C97FC928EF3EEF0089586C /* SteamclUtilityBelt */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = SteamclUtilityBelt;

--- a/mvvm-ios/MVVMSample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/mvvm-ios/MVVMSample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,6 +1,33 @@
 {
   "pins" : [
     {
+      "identity" : "cwlcatchexception",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/mattgallagher/CwlCatchException.git",
+      "state" : {
+        "revision" : "35f9e770f54ce62dd8526470f14c6e137cef3eea",
+        "version" : "2.1.1"
+      }
+    },
+    {
+      "identity" : "cwlpreconditiontesting",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/mattgallagher/CwlPreconditionTesting.git",
+      "state" : {
+        "revision" : "c21f7bab5ca8eee0a9998bbd17ca1d0eb45d4688",
+        "version" : "2.1.0"
+      }
+    },
+    {
+      "identity" : "factory-bird",
+      "kind" : "remoteSourceControl",
+      "location" : "git@github.com:steamclock/factory-bird.git",
+      "state" : {
+        "branch" : "main",
+        "revision" : "1bf791d55bf5a98736839e3f0fd39c18d021ab22"
+      }
+    },
+    {
       "identity" : "kingfisher",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/onevcat/Kingfisher.git",
@@ -25,6 +52,24 @@
       "state" : {
         "branch" : "main",
         "revision" : "258a2956a60576cd302c01c58c954a8aefa00788"
+      }
+    },
+    {
+      "identity" : "nimble",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/Quick/Nimble",
+      "state" : {
+        "branch" : "main",
+        "revision" : "b7f6c49acdb247e3158198c5448b38c3cc595533"
+      }
+    },
+    {
+      "identity" : "quick",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/Quick/Quick.git",
+      "state" : {
+        "branch" : "main",
+        "revision" : "df7cbda58fea600a40ba04113b6a5aeff1e4bae4"
       }
     },
     {

--- a/mvvm-ios/MVVMSampleTests/MVVMSampleTests.swift
+++ b/mvvm-ios/MVVMSampleTests/MVVMSampleTests.swift
@@ -5,6 +5,8 @@
 //  Created by Nigel Brooke on 2021-04-29.
 //
 
+import Nimble
+import Quick
 import XCTest
 @testable import MVVMSample
 

--- a/mvvm-ios/MVVMSampleTests/TestResources/Mock/Repository/MockPostRepository.swift
+++ b/mvvm-ios/MVVMSampleTests/TestResources/Mock/Repository/MockPostRepository.swift
@@ -7,6 +7,7 @@
 
 import Combine
 import Foundation
+import SteamclUtilityBelt
 @testable import MVVMSample
 
 class MockPostRepository: PostRepositoryProtocol {
@@ -19,9 +20,10 @@ class MockPostRepository: PostRepositoryProtocol {
         self.posts = posts
     }
 
-    func getPost(id: String, cacheMode: CacheMode) async throws -> Post {
-        posts.first!
+    func getPost(id: Int, cacheMode: CacheMode) async throws -> Post {
+        posts.first { $0.id == id }!
     }
+
 
     func getPostList(cacheMode: CacheMode) async throws -> [Post] {
         posts

--- a/mvvm-ios/MVVMSampleTests/TestResources/Mock/Repository/MockUserRepository.swift
+++ b/mvvm-ios/MVVMSampleTests/TestResources/Mock/Repository/MockUserRepository.swift
@@ -7,6 +7,7 @@
 
 import Combine
 import Foundation
+import SteamclUtilityBelt
 @testable import MVVMSample
 
 class MockUserRepository: UserRepositoryProtocol {

--- a/mvvm-ios/MVVMSampleTests/TestResources/Mock/Service/MockPostService.swift
+++ b/mvvm-ios/MVVMSampleTests/TestResources/Mock/Service/MockPostService.swift
@@ -9,9 +9,13 @@ import Foundation
 @testable import MVVMSample
 
 class MockPostService: PostServiceProtocol {
-    @TestData("Posts") var posts: [Post]
+    var posts: [Post]
 
-    func getPost(id: String) async throws -> Post {
+    init() {
+        posts = Post.mockedArrayOf(10)
+    }
+
+    func getPost(id: Int) async throws -> Post {
         posts.first!
     }
 

--- a/mvvm-ios/MVVMSampleTests/TestResources/Post+Mockable.swift
+++ b/mvvm-ios/MVVMSampleTests/TestResources/Post+Mockable.swift
@@ -1,0 +1,20 @@
+//
+//  Post+Mockable.swift
+//  MVVMSampleTests
+//
+//  Created by Brendan on 2023-01-10.
+//
+
+import FactoryBird
+import Foundation
+@testable import MVVMSample
+
+extension Post: Mockable {
+    public static var mocked: MVVMSample.Post {
+        Post(
+            userId: Mocked.int(),
+            id: Mocked.int(),
+            title: Mocked.string,
+            body: Mocked.string)
+    }
+}

--- a/mvvm-ios/MVVMSampleTests/TestResources/User+Mockable.swift
+++ b/mvvm-ios/MVVMSampleTests/TestResources/User+Mockable.swift
@@ -1,0 +1,20 @@
+//
+//  User+Mockable.swift
+//  MVVMSampleTests
+//
+//  Created by Brendan on 2023-01-10.
+//
+
+import FactoryBird
+import Foundation
+@testable import MVVMSample
+
+extension User: Mockable {
+    public static var mocked: User {
+        User(
+            id: Mocked.int(),
+            name: Mocked.fullName)
+    }
+}
+
+


### PR DESCRIPTION
We don't necessarily need to merge these changes, but given all the work we've been doing recently researching ways to level up our testing suite, I thought it might be handy to see some of those changes in action...

3 major components here:

1. Quick - gives us the Rspec-like testing language, using things like `describes`, `it`, `beforeEach`, etc...
2. Nimble - matcher functions like `expect.to.equal`, etc
3. Factory Bird - our own library that adds the `Mockable` protocol, replacing the `TestData` property wrapper