### PR TITLE
Reference steamclog library by branch and upgrade Sentry dependency

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/getsentry/sentry-cocoa",
       "state" : {
-        "revision" : "c3c19e29f775ee95b77aa3168f3e2fd6c20deba6",
-        "version" : "7.31.3"
+        "revision" : "f45e9c62d7a4d9258ac3cf35a3acf9dbab4481d1",
+        "version" : "8.43.0"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/steamclock/steamclog-swift.git",
       "state" : {
-        "branch" : "master",
-        "revision" : "a441cd43d3e85d78783f1c760d2ea68854872668"
+        "revision" : "a441cd43d3e85d78783f1c760d2ea68854872668",
+        "version" : "2.3.1"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
         .library(name: "NiceArchitecture", targets: ["NiceArchitecture"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/steamclock/steamclog-swift.git", from: "2.0.1")
+        .package(url: "https://github.com/steamclock/steamclog-swift.git", branch: "master")
     ],
     targets: [
         .target(

--- a/Package.swift
+++ b/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
         .library(name: "NiceArchitecture", targets: ["NiceArchitecture"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/steamclock/steamclog-swift.git", branch: "master")
+        .package(url: "https://github.com/steamclock/steamclog-swift.git", from: "2.3.1")
     ],
     targets: [
         .target(


### PR DESCRIPTION
Currently, determining the exact version that a package should reference for the `steamclog` package is difficult. 

For instance, the [README](https://github.com/steamclock/steamclog-swift/blob/master/README.md) mentions 2.3.0, but the latest version in the release list is 2.0.1. We're not addressing that issue in this PR. 

Therefore, to point to the latest version of the steamclog package, this PR makes the change to reference it by branch instead. 
 